### PR TITLE
Add nearest SR utilities

### DIFF
--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/MarketContext.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/MarketContext.mqh
@@ -263,8 +263,70 @@ private:
          return true;
       }
       return false;
-   }
+  }
 public:
+   /// Find nearest support level below the current price
+   double FindNearestSupport(const string symbol, ENUM_TIMEFRAMES tf,
+                             int lookback=50)
+   {
+      if(!EnsureHistory(symbol, tf, lookback+1))
+         return 0.0;
+      double lows[];
+      ArraySetAsSeries(lows,true);
+      if(CopyLow(symbol, tf, 1, lookback, lows)!=lookback)
+         return 0.0;
+      double price=iClose(symbol, tf, 0);
+      double level=0.0;
+      bool found=false;
+      for(int i=0;i<lookback;i++)
+      {
+         double l=lows[i];
+         if(l<price)
+         {
+            if(!found || l>level)
+            {
+               level=l;
+               found=true;
+            }
+         }
+      }
+      if(found)
+         return level;
+      int idx=ArrayMinimum(lows);
+      return lows[idx];
+   }
+
+   /// Find nearest resistance level above the current price
+   double FindNearestResistance(const string symbol, ENUM_TIMEFRAMES tf,
+                                int lookback=50)
+   {
+      if(!EnsureHistory(symbol, tf, lookback+1))
+         return 0.0;
+      double highs[];
+      ArraySetAsSeries(highs,true);
+      if(CopyHigh(symbol, tf, 1, lookback, highs)!=lookback)
+         return 0.0;
+      double price=iClose(symbol, tf, 0);
+      double level=0.0;
+      bool found=false;
+      for(int i=0;i<lookback;i++)
+      {
+         double h=highs[i];
+         if(h>price)
+         {
+            if(!found || h<level)
+            {
+               level=h;
+               found=true;
+            }
+         }
+      }
+      if(found)
+         return level;
+      int idx=ArrayMaximum(highs);
+      return highs[idx];
+   }
+
    /// Analisa apenas um timeframe
    PhaseInfo DetectPhaseSingle(const string symbol, ENUM_TIMEFRAMES tf, double rangeThr = 10.0)
    {

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/RangeBreakout.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/RangeBreakout.mqh
@@ -2,6 +2,7 @@
 #define INTEGRATEDPA_RANGEBREAKOUT_MQH
 #include "../Defs.mqh"
 #include "../Utils.mqh"
+#include "../MarketContext.mqh"
 
 class RangeBreakout
 {
@@ -68,13 +69,16 @@ public:
       double range=m_high-m_low;
       double entry=iClose(symbol,tf,1);
       double stop, target;
+      MarketContextAnalyzer ctx;
+      const int lvlLook=50;
       if(m_buySignal)
       {
          s.valid=true;
          s.direction=SIGNAL_BUY;
          s.phase=PHASE_RANGE;
          s.entry=entry;
-         stop   = m_high - range*0.2;   // stop below breakout level
+         stop   = ctx.FindNearestSupport(symbol,tf,lvlLook);
+         if(stop<=0.0) stop = m_high - range*0.2;   // fallback
          target = entry + range;        // projected range
          s.stop = stop;
          s.target = target;
@@ -87,7 +91,8 @@ public:
          s.direction=SIGNAL_SELL;
          s.phase=PHASE_RANGE;
          s.entry=entry;
-         stop   = m_low + range*0.2;
+         stop   = ctx.FindNearestResistance(symbol,tf,lvlLook);
+         if(stop<=0.0) stop   = m_low + range*0.2;
          target = entry - range;
          s.stop = stop;
          s.target = target;

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/RangeFade.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/RangeFade.mqh
@@ -1,6 +1,7 @@
 #ifndef INTEGRATEDPA_RANGEFADE_MQH
 #define INTEGRATEDPA_RANGEFADE_MQH
 #include "../Defs.mqh"
+#include "../MarketContext.mqh"
 
 class RangeFade
 {
@@ -51,13 +52,16 @@ public:
 
       double range=m_high-m_low;
       double entry=iClose(symbol,tf,1);
+      MarketContextAnalyzer ctx;
+      const int lvlLook=50;
       if(m_buySignal)
       {
          s.valid=true;
          s.direction=SIGNAL_BUY;
          s.phase=PHASE_RANGE;
          s.entry=entry;
-         double stop  = m_low - range*0.2;     // stop beyond range
+         double stop  = ctx.FindNearestSupport(symbol,tf,lvlLook);
+         if(stop<=0.0) stop = m_low - range*0.2;
          double target= m_high;               // aim for opposite extreme
          s.stop = stop;
          s.target = target;
@@ -70,7 +74,8 @@ public:
          s.direction=SIGNAL_SELL;
          s.phase=PHASE_RANGE;
          s.entry=entry;
-         double stop  = m_high + range*0.2;
+         double stop  = ctx.FindNearestResistance(symbol,tf,lvlLook);
+         if(stop<=0.0) stop = m_high + range*0.2;
          double target= m_low;
          s.stop = stop;
          s.target = target;


### PR DESCRIPTION
## Summary
- add support/resistance search helpers in MarketContext
- use these helpers in RangeFade and RangeBreakout strategies

## Testing
- `bash scripts/compile.sh && tail -n 20 build/compile.log`

------
https://chatgpt.com/codex/tasks/task_e_685446c828c48320a6ee328fd492b371