### PR TITLE
Add volatility and trend metrics

### DIFF
--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/RiskManager.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/RiskManager.mqh
@@ -3,6 +3,7 @@
 #include <Trade/SymbolInfo.mqh>
 #include "Defs.mqh"
 #include "Utils.mqh"
+#include "MarketContext.mqh"
 
 class RiskManager
 {
@@ -167,6 +168,23 @@ public:
    void UpdateAccountInfo()
    {
       m_equity=AccountInfoDouble(ACCOUNT_EQUITY);
+   }
+
+   /// Wrapper to access MarketContext volatility ratio
+   double GetVolatilityRatio(const string symbol, ENUM_TIMEFRAMES tf,
+                             int atrPeriod=DEFAULT_ATR_PERIOD,
+                             int lookback=20)
+   {
+      MarketContextAnalyzer ctx;
+      return ctx.GetVolatilityRatio(symbol, tf, atrPeriod, lookback);
+   }
+
+   /// Wrapper to access MarketContext trend strength metric
+   double GetTrendStrength(const string symbol, ENUM_TIMEFRAMES tf,
+                           int atrPeriod=DEFAULT_ATR_PERIOD)
+   {
+      MarketContextAnalyzer ctx;
+      return ctx.GetTrendStrength(symbol, tf, atrPeriod);
    }
 };
 

--- a/prStory/Task_MarketMetrics_Summary.md
+++ b/prStory/Task_MarketMetrics_Summary.md
@@ -1,0 +1,31 @@
+# Task: Market Metrics
+**Date:** 2025-06-13 22:30 UTC
+
+## Problem
+Strategies lacked quantitative measures of volatility and trend strength for adaptive risk management.
+
+## Solution
+- Added `GetVolatilityRatio` and `GetTrendStrength` methods to `MarketContext.mqh`.
+- Provided wrappers in `RiskManager.mqh` so risk logic can query these metrics.
+- `GetVolatilityRatio` compares the current ATR to the average of prior periods.
+- `GetTrendStrength` returns the average EMA spacing normalized by ATR.
+
+## Code (excerpt)
+```mql5
+// MarketContext.mqh
+double GetVolatilityRatio(const string symbol,ENUM_TIMEFRAMES tf,int atrPeriod,int lookback)
+{
+    int handle=GetATRHandle(symbol,tf,atrPeriod);
+    // ... compute ratio ...
+}
+
+double GetTrendStrength(const string symbol,ENUM_TIMEFRAMES tf,int atrPeriod)
+{
+    int h9=GetEMAHandle(symbol,tf,9);
+    // ... compute normalized spacing ...
+}
+```
+
+## Manual Testing Instructions
+- [ ] Compile the EA using `scripts/compile.sh`.
+- [ ] In MetaTrader, call the new methods from a script to verify values.


### PR DESCRIPTION
## Summary
- extend MarketContext with `GetVolatilityRatio` and `GetTrendStrength`
- expose the metrics through RiskManager
- document the change

## Testing
- `bash scripts/compile.sh` *(fails: wine not available)*

------
https://chatgpt.com/codex/tasks/task_e_68544c34ad5083208671f0b90b437590