### PR TITLE
Add srLookback per-asset support

### DIFF
--- a/IntegratedPA_EA/MQL5/Experts/IntegratedPA_EA.mq5
+++ b/IntegratedPA_EA/MQL5/Experts/IntegratedPA_EA.mq5
@@ -453,7 +453,7 @@ void OnTick()
       MARKET_PHASE phase = g_market.DetectPhaseMTF(symbol, MainTimeframe, g_assets[i].ctxTf,
                                                    g_assets[i].rangeThreshold);
 
-      Signal sig = g_engine.Generate(symbol, phase, MainTimeframe);
+      Signal sig = g_engine.Generate(g_assets[i], phase, MainTimeframe);
 
       if (!sig.valid)
          continue;
@@ -589,6 +589,7 @@ bool SetupAssets()
       g_assets[idx].ctxTf = PERIOD_H4;   // MTF context per trading guide
       g_assets[idx].atrTf = MainTimeframe;
       g_assets[idx].atrPeriod = 21; // periodo maior para volatilidade do BTC
+      g_assets[idx].srLookback = 50;
       g_assets[idx].prevHigh = 0.0;
       g_assets[idx].prevLow = 0.0;
       g_assets[idx].dailyBias = BIAS_NEUTRAL;
@@ -612,6 +613,7 @@ bool SetupAssets()
       g_assets[idx].ctxTf = PERIOD_H1; // context timeframe per guide
       g_assets[idx].atrTf = MainTimeframe;
       g_assets[idx].atrPeriod = 14; // periodo padrao para o dolar
+      g_assets[idx].srLookback = 50;
       g_assets[idx].prevHigh = 0.0;
       g_assets[idx].prevLow = 0.0;
       g_assets[idx].dailyBias = BIAS_NEUTRAL;
@@ -635,6 +637,7 @@ bool SetupAssets()
       g_assets[idx].ctxTf = PERIOD_H1;   // context timeframe per guide
       g_assets[idx].atrTf = PERIOD_D1;   // volatilidade medida no diário conforme guia
       g_assets[idx].atrPeriod = 14;      // periodo do ATR diario
+      g_assets[idx].srLookback = 50;
       g_assets[idx].prevHigh = 0.0;
       g_assets[idx].prevLow = 0.0;
       g_assets[idx].dailyBias = BIAS_NEUTRAL;

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/Defs.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/Defs.mqh
@@ -76,6 +76,7 @@ struct AssetConfig
    ENUM_TIMEFRAMES ctxTf; ///< Timeframe de contexto para confirmacao
    ENUM_TIMEFRAMES atrTf; ///< Timeframe do ATR para stops
    int      atrPeriod;    ///< Periodo do ATR por ativo
+   int      srLookback;   ///< Lookback para suportes/resistências
    double   prevHigh;     ///< Máxima do dia anterior
    double   prevLow;      ///< Mínima do dia anterior
    DAILY_BIAS dailyBias;  ///< Viés diário calculado na preparação

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/MarketContext.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/MarketContext.mqh
@@ -174,8 +174,8 @@ private:
          return false;
 
 
-      double near_supp = FindNearestSupport(_Symbol, PERIOD_M3);
-      double near_ress = FindNearestResistance(_Symbol, PERIOD_M3);
+      double near_supp = FindNearestSupport(_Symbol, PERIOD_M3, 50);
+      double near_ress = FindNearestResistance(_Symbol, PERIOD_M3, 50);
       DrawSupportResistanceLines(_Symbol,PERIOD_M3,near_supp, near_ress);
       desc = "Trend";
       if (dir > 0)
@@ -276,7 +276,7 @@ private:
 public:
    /// Find nearest support level below the current price
    double FindNearestSupport(const string symbol, ENUM_TIMEFRAMES tf,
-                             int lookback = 50)
+                             int lookback)
    {
       if (!EnsureHistory(symbol, tf, lookback + 1))
          return 0.0;
@@ -307,7 +307,7 @@ public:
 
    /// Find nearest resistance level above the current price
    double FindNearestResistance(const string symbol, ENUM_TIMEFRAMES tf,
-                                int lookback = 50)
+                                int lookback)
    {
       if (!EnsureHistory(symbol, tf, lookback + 1))
          return 0.0;

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/SignalEngine.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/SignalEngine.mqh
@@ -63,16 +63,17 @@ public:
    ~SignalEngine(){}
 
    // Gera sinal principal
-   Signal Generate(const string symbol,MARKET_PHASE phase,ENUM_TIMEFRAMES tf)
+   Signal Generate(const AssetConfig &asset, MARKET_PHASE phase, ENUM_TIMEFRAMES tf)
    {
+      const string symbol = asset.symbol;
       Signal s; s.valid=false;
       switch(phase)
       {
          case PHASE_TREND:
-            s=GenerateTrendSignals(symbol,tf);
+            s=GenerateTrendSignals(asset,tf);
             break;
          // case PHASE_RANGE:
-         //    s=GenerateRangeSignals(symbol,tf);
+         //    s=GenerateRangeSignals(asset,tf);
          //    break;
          // case PHASE_REVERSAL:
          //    s=GenerateReversalSignals(symbol,tf);
@@ -85,8 +86,9 @@ public:
 
 private:
    // Estratégias de tendência
-   Signal GenerateTrendSignals(const string symbol,ENUM_TIMEFRAMES tf)
+   Signal GenerateTrendSignals(const AssetConfig &asset, ENUM_TIMEFRAMES tf)
    {
+      const string symbol = asset.symbol;
       Signal s; s.valid=false;
       // Prefer Spike and Channel detection before other trend strategies
       SpikeAndChannel sac;
@@ -113,23 +115,25 @@ private:
    }
 
    // Estratégias de range
-   Signal GenerateRangeSignals(const string symbol,ENUM_TIMEFRAMES tf)
+   Signal GenerateRangeSignals(const AssetConfig &asset, ENUM_TIMEFRAMES tf)
    {
+      const string symbol = asset.symbol;
       Signal s; s.valid=false;
       RangeBreakout br;
       if(UseRangeBreakout && br.Identify(symbol,tf))
-         return br.GenerateSignal(symbol,tf);
+         return br.GenerateSignal(symbol,tf,asset.srLookback);
 
       RangeFade rf;
       if(UseRangeFade && rf.Identify(symbol,tf))
-         return rf.GenerateSignal(symbol,tf);
+         return rf.GenerateSignal(symbol,tf,asset.srLookback);
 
       return s;
    }
 
    // Estratégias de reversão
-  Signal GenerateReversalSignals(const string symbol,ENUM_TIMEFRAMES tf)
+  Signal GenerateReversalSignals(const AssetConfig &asset, ENUM_TIMEFRAMES tf)
   {
+      const string symbol = asset.symbol;
       Signal s; s.valid=false;
       WedgeReversal wr;
       bool isRising=false;

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/Utils.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/Utils.mqh
@@ -848,7 +848,7 @@ inline bool LoadAssetCsv(const string path, ENUM_TIMEFRAMES mainTf, AssetConfig 
 
       {
          // discard header line
-         for (int i = 0; i < 12; i++)
+         for (int i = 0; i < 13; i++)
             FileReadString(handle);
          first = false;
          continue;
@@ -864,6 +864,7 @@ inline bool LoadAssetCsv(const string path, ENUM_TIMEFRAMES mainTf, AssetConfig 
       string ctxTfStr = FileReadString(handle);
       string atrTfStr = FileReadString(handle);
       int atrPeriod = (int)FileReadNumber(handle);
+      int srLookback = (int)FileReadNumber(handle);
       double trailStart = FileReadNumber(handle);
       double trailDist  = FileReadNumber(handle);
 
@@ -886,6 +887,7 @@ inline bool LoadAssetCsv(const string path, ENUM_TIMEFRAMES mainTf, AssetConfig 
       cfg.ctxTf = TfFromString(ctxTfStr, mainTf);
       cfg.atrTf = TfFromString(atrTfStr, mainTf);
       cfg.atrPeriod = atrPeriod;
+      cfg.srLookback = srLookback;
       cfg.prevHigh = 0.0;
       cfg.prevLow = 0.0;
       cfg.dailyBias = BIAS_NEUTRAL;

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/RangeBreakout.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/RangeBreakout.mqh
@@ -60,7 +60,7 @@ public:
    }
 
    // Generate breakout signal using range projection
-   Signal GenerateSignal(const string symbol,ENUM_TIMEFRAMES tf)
+   Signal GenerateSignal(const string symbol, ENUM_TIMEFRAMES tf, int srLookback)
    {
       Signal s; s.valid=false;
       if(!Identify(symbol,tf))
@@ -70,7 +70,7 @@ public:
       double entry=iClose(symbol,tf,1);
       double stop, target;
       MarketContextAnalyzer ctx;
-      const int lvlLook=50;
+      const int lvlLook = srLookback;
       if(m_buySignal)
       {
          s.valid=true;

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/RangeFade.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/RangeFade.mqh
@@ -44,7 +44,7 @@ public:
    }
 
    // Generate trade signal fading the range extreme
-   Signal GenerateSignal(const string symbol,ENUM_TIMEFRAMES tf)
+   Signal GenerateSignal(const string symbol, ENUM_TIMEFRAMES tf, int srLookback)
    {
       Signal s; s.valid=false;
       if(!Identify(symbol,tf))
@@ -53,7 +53,7 @@ public:
       double range=m_high-m_low;
       double entry=iClose(symbol,tf,1);
       MarketContextAnalyzer ctx;
-      const int lvlLook=50;
+      const int lvlLook = srLookback;
       if(m_buySignal)
       {
          s.valid=true;

--- a/IntegratedPA_EA/assets.csv
+++ b/IntegratedPA_EA/assets.csv
@@ -1,4 +1,4 @@
-symbol,enabled,minLot,maxLot,lotStep,rangeThreshold,minStop,riskPercent,ctxTf,atrTf,atrPeriod,trailStart,trailDist
-BIT,false,0.01,10.0,0.01,50,1000,0.4,H4,MAIN,21,4000,900
-WDO,false,1.0,100.0,1.0,2,7,0.8,H1,MAIN,14,50,12
-WIN,true,1.0,100.0,1.0,80,200,1.2,H4,D1,14,200,200
+symbol,enabled,minLot,maxLot,lotStep,rangeThreshold,minStop,riskPercent,ctxTf,atrTf,atrPeriod,srLookback,trailStart,trailDist
+BIT,false,0.01,10.0,0.01,50,1000,0.4,H4,MAIN,21,50,4000,900
+WDO,false,1.0,100.0,1.0,2,7,0.8,H1,MAIN,14,50,50,12
+WIN,true,1.0,100.0,1.0,80,200,1.2,H4,D1,14,50,200,200


### PR DESCRIPTION
## Summary
- extend `AssetConfig` with `srLookback`
- include lookback column in `assets.csv`
- load/assign lookback in `SetupAssets`
- require lookback param in support/resistance helpers
- forward lookback through `SignalEngine` and range strategies

## Testing
- `bash scripts/compile.sh` *(fails: wine not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685451d756d083209e45e932ffe6c4a3