### PR TITLE
Implement support/resistance zone detection

### DIFF
--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/MarketContext.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/MarketContext.mqh
@@ -303,6 +303,23 @@ public:
 /// Find support zones on the last `bars` completed candles. Zones are grouped
 /// within +/-0.5 ATR of each other. Returns the number of detected zones and
 /// fills the `zones` array with the zone center prices sorted ascending.
+/// Sort helper used when ArraySort constants are unavailable
+inline void SortDoubleArray(double &arr[], int count, bool ascend)
+{
+   for(int i=0;i<count-1;i++)
+   {
+      for(int j=i+1;j<count;j++)
+      {
+         if((ascend && arr[i]>arr[j]) || (!ascend && arr[i]<arr[j]))
+         {
+            double tmp=arr[i];
+            arr[i]=arr[j];
+            arr[j]=tmp;
+         }
+      }
+   }
+}
+
 inline int FindSupportZones(const string symbol, ENUM_TIMEFRAMES tf,
                             int bars, double &zones[])
 {
@@ -336,7 +353,7 @@ inline int FindSupportZones(const string symbol, ENUM_TIMEFRAMES tf,
          }
       }
    }
-   ArraySort(zones, WHOLE_ARRAY, 0, MODE_ASCEND);
+   SortDoubleArray(zones, count, true);
    return count;
 }
 
@@ -377,7 +394,7 @@ inline int FindResistanceZones(const string symbol, ENUM_TIMEFRAMES tf,
          }
       }
    }
-   ArraySort(zones, WHOLE_ARRAY, 0, MODE_DESCEND);
+   SortDoubleArray(zones, count, false);
    return count;
 }
 

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/RangeBreakout.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/RangeBreakout.mqh
@@ -2,6 +2,7 @@
 #define INTEGRATEDPA_RANGEBREAKOUT_MQH
 #include "../Defs.mqh"
 #include "../Utils.mqh"
+#include "../MarketContext.mqh"
 
 class RangeBreakout
 {
@@ -17,16 +18,32 @@ public:
    bool Identify(const string symbol,ENUM_TIMEFRAMES tf)
    {
       const int lookback=20;
-      int idxHigh=iHighest(symbol,tf,MODE_HIGH,lookback,2);
-      int idxLow =iLowest(symbol,tf,MODE_LOW, lookback,2);
-      if(idxHigh==-1 || idxLow==-1)
-         return false;
-      m_high=iHigh(symbol,tf,idxHigh);
-      m_low =iLow(symbol,tf,idxLow);
+      double supZones[];
+      double resZones[];
+      int sCnt=FindSupportZones(symbol,tf,lookback+2,supZones);
+      int rCnt=FindResistanceZones(symbol,tf,lookback+2,resZones);
+
+      double close1=iClose(symbol,tf,1);
+      if(sCnt>0)
+         m_low=NearestZoneValue(supZones,sCnt,close1);
+      else
+      {
+         int idxLow=iLowest(symbol,tf,MODE_LOW,lookback,2);
+         if(idxLow==-1) return false;
+         m_low=iLow(symbol,tf,idxLow);
+      }
+
+      if(rCnt>0)
+         m_high=NearestZoneValue(resZones,rCnt,close1);
+      else
+      {
+         int idxHigh=iHighest(symbol,tf,MODE_HIGH,lookback,2);
+         if(idxHigh==-1) return false;
+         m_high=iHigh(symbol,tf,idxHigh);
+      }
       double range=m_high-m_low;
       if(range<=0.0)
          return false;
-      double close1=iClose(symbol,tf,1);
       double open1 =iOpen(symbol,tf,1);
 
       // volume médio para confirmação (Ferramentas Essenciais - Volume)

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/RangeFade.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/RangeFade.mqh
@@ -1,6 +1,7 @@
 #ifndef INTEGRATEDPA_RANGEFADE_MQH
 #define INTEGRATEDPA_RANGEFADE_MQH
 #include "../Defs.mqh"
+#include "../MarketContext.mqh"
 
 class RangeFade
 {
@@ -16,16 +17,32 @@ public:
    bool Identify(const string symbol,ENUM_TIMEFRAMES tf)
    {
       const int lookback=20;
-      int idxHigh=iHighest(symbol,tf,MODE_HIGH,lookback,1);
-      int idxLow =iLowest(symbol,tf,MODE_LOW, lookback,1);
-      if(idxHigh==-1 || idxLow==-1)
-         return false;
-      m_high=iHigh(symbol,tf,idxHigh);
-      m_low =iLow(symbol,tf,idxLow);
+      double supZones[];
+      double resZones[];
+      int sCnt=FindSupportZones(symbol,tf,lookback+2,supZones);
+      int rCnt=FindResistanceZones(symbol,tf,lookback+2,resZones);
+
+      double close1=iClose(symbol,tf,1);
+      if(sCnt>0)
+         m_low=NearestZoneValue(supZones,sCnt,close1);
+      else
+      {
+         int idxLow=iLowest(symbol,tf,MODE_LOW,lookback,1);
+         if(idxLow==-1) return false;
+         m_low=iLow(symbol,tf,idxLow);
+      }
+
+      if(rCnt>0)
+         m_high=NearestZoneValue(resZones,rCnt,close1);
+      else
+      {
+         int idxHigh=iHighest(symbol,tf,MODE_HIGH,lookback,1);
+         if(idxHigh==-1) return false;
+         m_high=iHigh(symbol,tf,idxHigh);
+      }
       double range=m_high-m_low;
       if(range<=0.0)
          return false;
-      double close1=iClose(symbol,tf,1);
       double open1 =iOpen(symbol,tf,1);
       double threshold=range*0.1; // 10% of range
 

--- a/prStory/Task_SupportResistanceZones_Summary.md
+++ b/prStory/Task_SupportResistanceZones_Summary.md
@@ -1,0 +1,27 @@
+# Task: Support & Resistance Zone Detection
+**Date:** 2025-06-19 20:56 UTC
+
+## Problem
+Strategies relied on raw highs and lows for range decisions and there was no shared method to locate support or resistance levels.
+
+## Solution
+- Added `FindSupportZones` and `FindResistanceZones` helpers in `MarketContext.mqh`.
+- Zones are formed by grouping local extrema within 0.5 ATR using cached ATR handles.
+- Convenience functions return the nearest zone to current price.
+- Updated `RangeFade` and `RangeBreakout` strategies to query these helpers for range extremes.
+
+## Code (excerpt)
+```mql5
+// MarketContext.mqh
+int FindSupportZones(const string symbol,ENUM_TIMEFRAMES tf,int bars,double &zones[]);
+int FindResistanceZones(const string symbol,ENUM_TIMEFRAMES tf,int bars,double &zones[]);
+double FindNearestSupport(const string symbol,ENUM_TIMEFRAMES tf,int bars);
+double FindNearestResistance(const string symbol,ENUM_TIMEFRAMES tf,int bars);
+```
+
+## Manual Testing Instructions
+- [ ] Run `scripts/compile.sh` to compile the EA (requires Wine).
+- [ ] In MetaTrader, confirm `RangeFade` and `RangeBreakout` continue to trigger around detected zones.
+
+## Observations / Notes
+- Compilation skipped in CI environments without Wine.


### PR DESCRIPTION
## Summary
- detect support and resistance zones via recent extrema in `MarketContext.mqh`
- expose helpers to fetch nearest zones
- update RangeFade and RangeBreakout to use the new logic
- document the feature

## Testing
- `bash scripts/compile.sh` *(fails: wine not available)*

------
https://chatgpt.com/codex/tasks/task_e_68547868da3483208df62aa35a4ba4ef