### PR TITLE
Refactor strategies to use individual context

### DIFF
--- a/IntegratedPA_EA/MQL5/Experts/IntegratedPA_EA.mq5
+++ b/IntegratedPA_EA/MQL5/Experts/IntegratedPA_EA.mq5
@@ -6,7 +6,6 @@
 
 #include <Trade/Trade.mqh>
 #include <Arrays/ArrayObj.mqh>
-#include <IntegratedPA/MarketContext.mqh>
 #include <IntegratedPA/RiskManager.mqh>
 #include <IntegratedPA/TradeExecutor.mqh>
 #include <IntegratedPA/Logger.mqh>
@@ -53,7 +52,6 @@ input bool UsePreMarketRoutine = true;
 
 #include <IntegratedPA/SignalEngine.mqh>
 
-MarketContext *g_market = NULL;
 SignalEngine *g_engine = NULL;
 RiskManager *g_risk = NULL;
 TradeExecutor *g_exec = NULL;
@@ -366,7 +364,6 @@ int OnInit()
 
    ResetDailyLimits();
 
-   g_market = new MarketContext();
    g_engine = new SignalEngine();
    g_risk = new RiskManager(RiskPerTrade, MaxTotalRisk);
    g_exec = new TradeExecutor();
@@ -381,11 +378,6 @@ int OnInit()
 void OnDeinit(const int reason)
 {
    EventKillTimer();
-   if (g_market)
-   {
-      delete g_market;
-      g_market = NULL;
-   }
    if (g_engine)
    {
       delete g_engine;
@@ -428,7 +420,7 @@ void OnTick()
    MaybeRunPreMarketRoutine();
    // manage existing positions first
    if (g_exec)
-      g_exec.ManageOpenPositions(g_market, g_assets, ArraySize(g_assets), MainTimeframe);
+      g_exec.ManageOpenPositions(g_assets, ArraySize(g_assets), MainTimeframe);
    MaybeCloseEODPositions();
 
    if (g_dailyPaused)
@@ -448,7 +440,6 @@ void OnTick()
          continue;
 
       
-      g_market.set_sr(symbol);
 
       Signal sig = g_engine.Generate(symbol, MainTimeframe, g_assets[i]);
       

--- a/IntegratedPA_EA/MQL5/Experts/IntegratedPA_EA.mq5
+++ b/IntegratedPA_EA/MQL5/Experts/IntegratedPA_EA.mq5
@@ -450,11 +450,8 @@ void OnTick()
       
       g_market.set_sr(symbol);
 
-      MARKET_PHASE phase = g_market.DetectPhaseMTF(symbol, MainTimeframe, g_assets[i].ctxTf,
-                                                   g_assets[i].rangeThreshold);
-
-      Signal sig = g_engine.Generate(symbol, phase, MainTimeframe);
-
+      Signal sig = g_engine.Generate(symbol, MainTimeframe, g_assets[i]);
+      
       if (!sig.valid)
          continue;
 
@@ -498,7 +495,7 @@ void OnTick()
          }
       }
 
-      OrderRequest req = g_risk.BuildRequest(symbol, sig, phase, g_assets[i].riskPercent);
+      OrderRequest req = g_risk.BuildRequest(symbol, sig, sig.phase, g_assets[i].riskPercent);
       if (g_risk.CanOpen(req))
          g_exec.Execute(req);
       else if (g_log)

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/SignalEngine.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/SignalEngine.mqh
@@ -63,91 +63,85 @@ public:
    ~SignalEngine(){}
 
    // Gera sinal principal
-   Signal Generate(const string symbol,MARKET_PHASE phase,ENUM_TIMEFRAMES tf)
+   Signal Generate(const string symbol,ENUM_TIMEFRAMES tf,const AssetConfig &asset)
    {
       Signal s; s.valid=false;
-      switch(phase)
+
+      if(UseSpikeAndChannel)
       {
-         case PHASE_TREND:
-            s=GenerateTrendSignals(symbol,tf);
-            break;
-         // case PHASE_RANGE:
-         //    s=GenerateRangeSignals(symbol,tf);
-         //    break;
-         // case PHASE_REVERSAL:
-         //    s=GenerateReversalSignals(symbol,tf);
-         //    break;
-         default:
-            break;
+         SpikeAndChannel sac;
+         if(sac.Identify(symbol,tf,asset))
+            return sac.GenerateSignal(symbol,tf,asset);
       }
+
+      if(UsePullbackMA)
+      {
+         PullbackToMA pb;
+         if(pb.Identify(symbol,tf,asset))
+            return pb.GenerateSignal(symbol,tf,asset);
+      }
+
+      if(UseFibonacciRetrace)
+      {
+         FibonacciRetrace fr;
+         if(fr.Identify(symbol,tf,asset))
+            return fr.GenerateSignal(symbol,tf,asset);
+      }
+
+      if(UseBollingerStochastic)
+      {
+         BollingerStochastic bs;
+         if(bs.Identify(symbol,tf,asset))
+            return bs.GenerateSignal(symbol,tf,asset);
+      }
+
+      if(UseTrendRangeDay)
+      {
+         TrendRangeDay trd;
+         if(trd.Identify(symbol,tf,asset))
+            return trd.GenerateSignal(symbol,tf,asset);
+      }
+
+      if(UseRangeBreakout)
+      {
+         RangeBreakout br;
+         if(br.Identify(symbol,tf,asset))
+            return br.GenerateSignal(symbol,tf,asset);
+      }
+
+      if(UseRangeFade)
+      {
+         RangeFade rf;
+         if(rf.Identify(symbol,tf,asset))
+            return rf.GenerateSignal(symbol,tf,asset);
+      }
+
+      if(UseWedgeReversal)
+      {
+         WedgeReversal wr;
+         bool rising=false;
+         if(wr.Identify(symbol,tf,rising,asset))
+            return wr.GenerateSignal(symbol,tf,asset);
+      }
+
+      if(UseMeanReversion50200)
+      {
+         MeanReversion50to200 mr;
+         bool buy=false;
+         if(mr.Identify(symbol,tf,buy,asset))
+            return mr.GenerateSignal(symbol,tf,asset);
+      }
+
+      if(UseVWAPReversion)
+      {
+         VWAPReversion vr;
+         bool buy2=false;
+         if(vr.Identify(symbol,tf,buy2,asset))
+            return vr.GenerateSignal(symbol,tf,asset);
+      }
+
       return s;
    }
-
-private:
-   // Estratégias de tendência
-   Signal GenerateTrendSignals(const string symbol,ENUM_TIMEFRAMES tf)
-   {
-      Signal s; s.valid=false;
-      // Prefer Spike and Channel detection before other trend strategies
-      SpikeAndChannel sac;
-      if(UseSpikeAndChannel && sac.Identify(symbol,tf))
-         return sac.GenerateSignal(symbol,tf);
-
-      // PullbackToMA pb;
-      // if(UsePullbackMA && pb.Identify(symbol,tf))
-      //    return pb.GenerateSignal(symbol,tf);
-
-      // FibonacciRetrace fr;
-      // if(UseFibonacciRetrace && fr.Identify(symbol,tf))
-      //    return fr.GenerateSignal(symbol,tf);
-
-      // BollingerStochastic bs;
-      // if(UseBollingerStochastic && bs.Identify(symbol,tf))
-      //    return bs.GenerateSignal(symbol,tf);
-
-      // TrendRangeDay trd;
-      // if(UseTrendRangeDay && trd.Identify(symbol,tf))
-      //    return trd.GenerateSignal(symbol,tf);
-
-      return s;
-   }
-
-   // Estratégias de range
-   Signal GenerateRangeSignals(const string symbol,ENUM_TIMEFRAMES tf)
-   {
-      Signal s; s.valid=false;
-      RangeBreakout br;
-      if(UseRangeBreakout && br.Identify(symbol,tf))
-         return br.GenerateSignal(symbol,tf);
-
-      RangeFade rf;
-      if(UseRangeFade && rf.Identify(symbol,tf))
-         return rf.GenerateSignal(symbol,tf);
-
-      return s;
-   }
-
-   // Estratégias de reversão
-  Signal GenerateReversalSignals(const string symbol,ENUM_TIMEFRAMES tf)
-  {
-      Signal s; s.valid=false;
-      WedgeReversal wr;
-      bool isRising=false;
-      if(UseWedgeReversal && wr.Identify(symbol,tf,isRising))
-         return wr.GenerateSignal(symbol,tf);
-
-      MeanReversion50to200 mr;
-      bool buy=false;
-      if(UseMeanReversion50200 && mr.Identify(symbol,tf,buy))
-         return mr.GenerateSignal(symbol,tf);
-
-      VWAPReversion vr;
-      bool buy2=false;
-      if(UseVWAPReversion && vr.Identify(symbol,tf,buy2))
-         return vr.GenerateSignal(symbol,tf);
-
-      return s;
-  }
 };
 
 #endif // INTEGRATEDPA_SIGNALENGINE_MQH

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/SignalEngine.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/SignalEngine.mqh
@@ -69,79 +69,81 @@ public:
 
       if(UseSpikeAndChannel)
       {
-         SpikeAndChannel sac;
-         if(sac.Identify(symbol,tf,asset))
-            return sac.GenerateSignal(symbol,tf,asset);
+         if(m_spikeAndChannel.Identify(symbol,tf,asset))
+            return m_spikeAndChannel.GenerateSignal(symbol,tf,asset);
       }
 
       if(UsePullbackMA)
       {
-         PullbackToMA pb;
-         if(pb.Identify(symbol,tf,asset))
-            return pb.GenerateSignal(symbol,tf,asset);
+         if(m_pullbackMA.Identify(symbol,tf,asset))
+            return m_pullbackMA.GenerateSignal(symbol,tf,asset);
       }
 
       if(UseFibonacciRetrace)
       {
-         FibonacciRetrace fr;
-         if(fr.Identify(symbol,tf,asset))
-            return fr.GenerateSignal(symbol,tf,asset);
+         if(m_fibRetrace.Identify(symbol,tf,asset))
+            return m_fibRetrace.GenerateSignal(symbol,tf,asset);
       }
 
       if(UseBollingerStochastic)
       {
-         BollingerStochastic bs;
-         if(bs.Identify(symbol,tf,asset))
-            return bs.GenerateSignal(symbol,tf,asset);
+         if(m_bollStoch.Identify(symbol,tf,asset))
+            return m_bollStoch.GenerateSignal(symbol,tf,asset);
       }
 
       if(UseTrendRangeDay)
       {
-         TrendRangeDay trd;
-         if(trd.Identify(symbol,tf,asset))
-            return trd.GenerateSignal(symbol,tf,asset);
+         if(m_trendRangeDay.Identify(symbol,tf,asset))
+            return m_trendRangeDay.GenerateSignal(symbol,tf,asset);
       }
 
       if(UseRangeBreakout)
       {
-         RangeBreakout br;
-         if(br.Identify(symbol,tf,asset))
-            return br.GenerateSignal(symbol,tf,asset);
+         if(m_rangeBreakout.Identify(symbol,tf,asset))
+            return m_rangeBreakout.GenerateSignal(symbol,tf,asset);
       }
 
       if(UseRangeFade)
       {
-         RangeFade rf;
-         if(rf.Identify(symbol,tf,asset))
-            return rf.GenerateSignal(symbol,tf,asset);
+         if(m_rangeFade.Identify(symbol,tf,asset))
+            return m_rangeFade.GenerateSignal(symbol,tf,asset);
       }
 
       if(UseWedgeReversal)
       {
-         WedgeReversal wr;
          bool rising=false;
-         if(wr.Identify(symbol,tf,rising,asset))
-            return wr.GenerateSignal(symbol,tf,asset);
+         if(m_wedgeRev.Identify(symbol,tf,rising,asset))
+            return m_wedgeRev.GenerateSignal(symbol,tf,asset);
       }
 
       if(UseMeanReversion50200)
       {
-         MeanReversion50to200 mr;
          bool buy=false;
-         if(mr.Identify(symbol,tf,buy,asset))
-            return mr.GenerateSignal(symbol,tf,asset);
+         if(m_meanRev.Identify(symbol,tf,buy,asset))
+            return m_meanRev.GenerateSignal(symbol,tf,asset);
       }
 
       if(UseVWAPReversion)
       {
-         VWAPReversion vr;
          bool buy2=false;
-         if(vr.Identify(symbol,tf,buy2,asset))
-            return vr.GenerateSignal(symbol,tf,asset);
+         if(m_vwapRev.Identify(symbol,tf,buy2,asset))
+            return m_vwapRev.GenerateSignal(symbol,tf,asset);
       }
 
       return s;
    }
+
+private:
+   SpikeAndChannel      m_spikeAndChannel;
+   PullbackToMA         m_pullbackMA;
+   FibonacciRetrace     m_fibRetrace;
+   BollingerStochastic  m_bollStoch;
+   TrendRangeDay        m_trendRangeDay;
+   RangeBreakout        m_rangeBreakout;
+   RangeFade            m_rangeFade;
+   WedgeReversal        m_wedgeRev;
+   MeanReversion50to200 m_meanRev;
+   VWAPReversion        m_vwapRev;
 };
 
 #endif // INTEGRATEDPA_SIGNALENGINE_MQH

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/TradeExecutor.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/TradeExecutor.mqh
@@ -4,7 +4,6 @@
 #include "Defs.mqh"
 #include "Logger.mqh"
 #include "Utils.mqh"
-#include "MarketContext.mqh"
 
 class TradeExecutor
 {
@@ -57,7 +56,7 @@ public:
    }
 
    // manage partial exits and trailing stops as per the trading guide
-  void ManageOpenPositions(MarketContext *ctx,const AssetConfig &assets[],int count,ENUM_TIMEFRAMES tf)
+  void ManageOpenPositions(const AssetConfig &assets[],int count,ENUM_TIMEFRAMES tf)
   {
       for(int i=PositionsTotal()-1;i>=0;i--)
       {
@@ -99,9 +98,7 @@ public:
                break;
            }
         }
-         MARKET_PHASE phase=PHASE_UNDEFINED;
-         if(ctx!=NULL)
-            phase=ctx.DetectPhase(symbol,tf,rangeThreshold);
+        MARKET_PHASE phase=PHASE_UNDEFINED;
 
          string gv="stage_"+(string)ticket;
          double stage=0.0;

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/BollingerStochastic.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/BollingerStochastic.mqh
@@ -9,6 +9,7 @@ class BollingerStochastic
 {
 private:
    bool m_buy;
+   MarketContextAnalyzer m_ctx;
 public:
    BollingerStochastic():m_buy(false){}
    ~BollingerStochastic(){}
@@ -16,8 +17,7 @@ public:
    // Identify setup according to guide lines 3600-3625
    bool Identify(const string symbol,ENUM_TIMEFRAMES tf,const AssetConfig &asset)
    {
-      MarketContextAnalyzer ctx;
-      if(ctx.DetectPhaseMTF(symbol,tf,asset.ctxTf,asset.rangeThreshold)!=PHASE_TREND)
+      if(m_ctx.DetectPhaseMTF(symbol,tf,asset.ctxTf,asset.rangeThreshold)!=PHASE_TREND)
          return false;
       double ema9=GetEMA(symbol,tf,9);
       double ema50=GetEMA(symbol,tf,50);

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/BollingerStochastic.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/BollingerStochastic.mqh
@@ -2,6 +2,7 @@
 #define INTEGRATEDPA_BOLLINGERSTOCHASTIC_MQH
 #include "../Defs.mqh"
 #include "../Utils.mqh"
+#include "../MarketContext.mqh"
 
 // Strategy combining Bollinger Bands context with Stochastic timing
 class BollingerStochastic
@@ -13,8 +14,11 @@ public:
    ~BollingerStochastic(){}
 
    // Identify setup according to guide lines 3600-3625
-   bool Identify(const string symbol,ENUM_TIMEFRAMES tf)
+   bool Identify(const string symbol,ENUM_TIMEFRAMES tf,const AssetConfig &asset)
    {
+      MarketContextAnalyzer ctx;
+      if(ctx.DetectPhaseMTF(symbol,tf,asset.ctxTf,asset.rangeThreshold)!=PHASE_TREND)
+         return false;
       double ema9=GetEMA(symbol,tf,9);
       double ema50=GetEMA(symbol,tf,50);
       double vwap=GetVWAP(symbol,tf);
@@ -49,10 +53,10 @@ public:
       return false;
    }
 
-   Signal GenerateSignal(const string symbol,ENUM_TIMEFRAMES tf)
+   Signal GenerateSignal(const string symbol,ENUM_TIMEFRAMES tf,const AssetConfig &asset)
    {
       Signal s; s.valid=false;
-      if(!Identify(symbol,tf))
+      if(!Identify(symbol,tf,asset))
          return s;
 
       double ema9 =GetEMA(symbol,tf,9);

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/FibonacciRetrace.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/FibonacciRetrace.mqh
@@ -14,6 +14,7 @@ private:
    double m_high;
    double m_low;
    bool   m_buySignal;
+   MarketContextAnalyzer m_ctx;
 public:
    FibonacciRetrace():m_high(0),m_low(0),m_buySignal(false){}
    ~FibonacciRetrace(){}
@@ -21,8 +22,7 @@ public:
    // Identifica a presen\u00e7a de retra\u00e7\u00e3o at\u00e9 61,8% e candle de revers\u00e3o
    bool Identify(const string symbol,ENUM_TIMEFRAMES tf,const AssetConfig &asset)
    {
-      MarketContextAnalyzer ctx;
-      if(ctx.DetectPhaseMTF(symbol,tf,asset.ctxTf,asset.rangeThreshold)!=PHASE_TREND)
+      if(m_ctx.DetectPhaseMTF(symbol,tf,asset.ctxTf,asset.rangeThreshold)!=PHASE_TREND)
          return false;
       const int lookback=50;
       int idxHigh=iHighest(symbol,tf,MODE_HIGH,lookback,1);

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/FibonacciRetrace.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/FibonacciRetrace.mqh
@@ -2,6 +2,7 @@
 #define INTEGRATEDPA_FIBONACCIRETRACE_MQH
 #include "../Defs.mqh"
 #include "../Utils.mqh"
+#include "../MarketContext.mqh"
 
 // Estrat\u00e9gia de revers\u00e3o na zona de ouro (61,8% de Fibonacci)
 // Inspirada nas orienta\u00e7\u00f5es do guia de trading em torno das linhas
@@ -18,8 +19,11 @@ public:
    ~FibonacciRetrace(){}
 
    // Identifica a presen\u00e7a de retra\u00e7\u00e3o at\u00e9 61,8% e candle de revers\u00e3o
-   bool Identify(const string symbol,ENUM_TIMEFRAMES tf)
+   bool Identify(const string symbol,ENUM_TIMEFRAMES tf,const AssetConfig &asset)
    {
+      MarketContextAnalyzer ctx;
+      if(ctx.DetectPhaseMTF(symbol,tf,asset.ctxTf,asset.rangeThreshold)!=PHASE_TREND)
+         return false;
       const int lookback=50;
       int idxHigh=iHighest(symbol,tf,MODE_HIGH,lookback,1);
       int idxLow =iLowest(symbol,tf,MODE_LOW ,lookback,1);
@@ -57,10 +61,10 @@ public:
    }
 
    // Gera sinal de compra ou venda com stop ap\u00f3s o n\u00edvel de 61,8%
-   Signal GenerateSignal(const string symbol,ENUM_TIMEFRAMES tf)
+   Signal GenerateSignal(const string symbol,ENUM_TIMEFRAMES tf,const AssetConfig &asset)
    {
       Signal s; s.valid=false;
-      if(!Identify(symbol,tf))
+      if(!Identify(symbol,tf,asset))
          return s;
 
       double point=SymbolInfoDouble(symbol,SYMBOL_POINT);

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/MeanReversion50to200.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/MeanReversion50to200.mqh
@@ -2,6 +2,7 @@
 #define INTEGRATEDPA_MEANREV50TO200_MQH
 #include "../Defs.mqh"
 #include "../Utils.mqh"
+#include "../MarketContext.mqh"
 
 //+------------------------------------------------------------------+
 //| Mean Reversion from EMA50 to EMA200                              |
@@ -17,8 +18,11 @@ public:
    ~MeanReversion50to200(){}
 
    // Identify mean reversion opportunity
-   bool Identify(const string symbol,ENUM_TIMEFRAMES tf,bool &buySignal)
+   bool Identify(const string symbol,ENUM_TIMEFRAMES tf,bool &buySignal,const AssetConfig &asset)
    {
+      MarketContextAnalyzer ctx;
+      if(ctx.DetectPhaseMTF(symbol,tf,asset.ctxTf,asset.rangeThreshold)!=PHASE_REVERSAL)
+         return false;
       double ema50 = GetEMA(symbol,tf,50);
       double ema200= GetEMA(symbol,tf,200);
       double price0= iClose(symbol,tf,0);
@@ -47,11 +51,11 @@ public:
    }
 
    // Generate trade signal
-   Signal GenerateSignal(const string symbol,ENUM_TIMEFRAMES tf)
+   Signal GenerateSignal(const string symbol,ENUM_TIMEFRAMES tf,const AssetConfig &asset)
    {
       Signal s; s.valid=false;
       bool buy=false;
-      if(!Identify(symbol,tf,buy))
+      if(!Identify(symbol,tf,buy,asset))
          return s;
 
       double point=SymbolInfoDouble(symbol,SYMBOL_POINT);

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/MeanReversion50to200.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/MeanReversion50to200.mqh
@@ -13,6 +13,8 @@
 //+------------------------------------------------------------------+
 class MeanReversion50to200
 {
+private:
+   MarketContextAnalyzer m_ctx;
 public:
    MeanReversion50to200(){}
    ~MeanReversion50to200(){}
@@ -20,8 +22,7 @@ public:
    // Identify mean reversion opportunity
    bool Identify(const string symbol,ENUM_TIMEFRAMES tf,bool &buySignal,const AssetConfig &asset)
    {
-      MarketContextAnalyzer ctx;
-      if(ctx.DetectPhaseMTF(symbol,tf,asset.ctxTf,asset.rangeThreshold)!=PHASE_REVERSAL)
+      if(m_ctx.DetectPhaseMTF(symbol,tf,asset.ctxTf,asset.rangeThreshold)!=PHASE_REVERSAL)
          return false;
       double ema50 = GetEMA(symbol,tf,50);
       double ema200= GetEMA(symbol,tf,200);

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/PullbackToMA.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/PullbackToMA.mqh
@@ -2,6 +2,7 @@
 #define INTEGRATEDPA_PULLBACKTOMA_MQH
 #include "../Defs.mqh"
 #include "../Utils.mqh"
+#include "../MarketContext.mqh"
 
 class PullbackToMA
 {
@@ -9,8 +10,11 @@ public:
     PullbackToMA(){}
     ~PullbackToMA(){}
 
-    bool Identify(const string symbol, ENUM_TIMEFRAMES tf)
+    bool Identify(const string symbol, ENUM_TIMEFRAMES tf,const AssetConfig &asset)
     {
+        MarketContextAnalyzer ctx;
+        if(ctx.DetectPhaseMTF(symbol,tf,asset.ctxTf,asset.rangeThreshold)!=PHASE_TREND)
+            return false;
         // avoid entries when price is already near the 50-200 mean
         if(CheckMeanReversion50to200(symbol, tf))
             return false;
@@ -32,9 +36,11 @@ public:
         return false;
     }
 
-    Signal GenerateSignal(const string symbol, ENUM_TIMEFRAMES tf)
+    Signal GenerateSignal(const string symbol, ENUM_TIMEFRAMES tf,const AssetConfig &asset)
     {
         Signal s; s.valid = false;
+        if(!Identify(symbol, tf, asset))
+            return s;
         double ema21 = GetEMA(symbol, tf, 21);
         double point = SymbolInfoDouble(symbol, SYMBOL_POINT);
 

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/PullbackToMA.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/PullbackToMA.mqh
@@ -6,14 +6,15 @@
 
 class PullbackToMA
 {
+private:
+    MarketContextAnalyzer m_ctx;
 public:
     PullbackToMA(){}
     ~PullbackToMA(){}
 
     bool Identify(const string symbol, ENUM_TIMEFRAMES tf,const AssetConfig &asset)
     {
-        MarketContextAnalyzer ctx;
-        if(ctx.DetectPhaseMTF(symbol,tf,asset.ctxTf,asset.rangeThreshold)!=PHASE_TREND)
+        if(m_ctx.DetectPhaseMTF(symbol,tf,asset.ctxTf,asset.rangeThreshold)!=PHASE_TREND)
             return false;
         // avoid entries when price is already near the 50-200 mean
         if(CheckMeanReversion50to200(symbol, tf))

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/RangeBreakout.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/RangeBreakout.mqh
@@ -10,6 +10,7 @@ private:
    double m_high;
    double m_low;
    bool   m_buySignal;
+   MarketContextAnalyzer m_ctx;
 public:
    RangeBreakout():m_high(0),m_low(0),m_buySignal(false){}
    ~RangeBreakout(){}
@@ -17,8 +18,7 @@ public:
    // Identify breakout beyond range boundaries with volume/VWAP confirmation
    bool Identify(const string symbol,ENUM_TIMEFRAMES tf,const AssetConfig &asset)
    {
-      MarketContextAnalyzer ctx;
-      if(ctx.DetectPhaseMTF(symbol,tf,asset.ctxTf,asset.rangeThreshold)!=PHASE_RANGE)
+      if(m_ctx.DetectPhaseMTF(symbol,tf,asset.ctxTf,asset.rangeThreshold)!=PHASE_RANGE)
          return false;
       const int lookback=20;
       int idxHigh=iHighest(symbol,tf,MODE_HIGH,lookback,2);

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/RangeBreakout.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/RangeBreakout.mqh
@@ -2,6 +2,7 @@
 #define INTEGRATEDPA_RANGEBREAKOUT_MQH
 #include "../Defs.mqh"
 #include "../Utils.mqh"
+#include "../MarketContext.mqh"
 
 class RangeBreakout
 {
@@ -14,8 +15,11 @@ public:
    ~RangeBreakout(){}
 
    // Identify breakout beyond range boundaries with volume/VWAP confirmation
-   bool Identify(const string symbol,ENUM_TIMEFRAMES tf)
+   bool Identify(const string symbol,ENUM_TIMEFRAMES tf,const AssetConfig &asset)
    {
+      MarketContextAnalyzer ctx;
+      if(ctx.DetectPhaseMTF(symbol,tf,asset.ctxTf,asset.rangeThreshold)!=PHASE_RANGE)
+         return false;
       const int lookback=20;
       int idxHigh=iHighest(symbol,tf,MODE_HIGH,lookback,2);
       int idxLow =iLowest(symbol,tf,MODE_LOW, lookback,2);
@@ -59,10 +63,10 @@ public:
    }
 
    // Generate breakout signal using range projection
-   Signal GenerateSignal(const string symbol,ENUM_TIMEFRAMES tf)
+   Signal GenerateSignal(const string symbol,ENUM_TIMEFRAMES tf,const AssetConfig &asset)
    {
       Signal s; s.valid=false;
-      if(!Identify(symbol,tf))
+      if(!Identify(symbol,tf,asset))
          return s;
 
       double range=m_high-m_low;

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/RangeFade.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/RangeFade.mqh
@@ -1,6 +1,7 @@
 #ifndef INTEGRATEDPA_RANGEFADE_MQH
 #define INTEGRATEDPA_RANGEFADE_MQH
 #include "../Defs.mqh"
+#include "../MarketContext.mqh"
 
 class RangeFade
 {
@@ -13,8 +14,11 @@ public:
    ~RangeFade(){}
 
    // Identify rejection at range extremes
-   bool Identify(const string symbol,ENUM_TIMEFRAMES tf)
+   bool Identify(const string symbol,ENUM_TIMEFRAMES tf,const AssetConfig &asset)
    {
+      MarketContextAnalyzer ctx;
+      if(ctx.DetectPhaseMTF(symbol,tf,asset.ctxTf,asset.rangeThreshold)!=PHASE_RANGE)
+         return false;
       const int lookback=20;
       int idxHigh=iHighest(symbol,tf,MODE_HIGH,lookback,1);
       int idxLow =iLowest(symbol,tf,MODE_LOW, lookback,1);
@@ -43,10 +47,10 @@ public:
    }
 
    // Generate trade signal fading the range extreme
-   Signal GenerateSignal(const string symbol,ENUM_TIMEFRAMES tf)
+   Signal GenerateSignal(const string symbol,ENUM_TIMEFRAMES tf,const AssetConfig &asset)
    {
       Signal s; s.valid=false;
-      if(!Identify(symbol,tf))
+      if(!Identify(symbol,tf,asset))
          return s;
 
       double range=m_high-m_low;

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/RangeFade.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/RangeFade.mqh
@@ -9,6 +9,7 @@ private:
    double m_high;
    double m_low;
    bool   m_buySignal;
+   MarketContextAnalyzer m_ctx;
 public:
    RangeFade():m_high(0),m_low(0),m_buySignal(false){}
    ~RangeFade(){}
@@ -16,8 +17,7 @@ public:
    // Identify rejection at range extremes
    bool Identify(const string symbol,ENUM_TIMEFRAMES tf,const AssetConfig &asset)
    {
-      MarketContextAnalyzer ctx;
-      if(ctx.DetectPhaseMTF(symbol,tf,asset.ctxTf,asset.rangeThreshold)!=PHASE_RANGE)
+      if(m_ctx.DetectPhaseMTF(symbol,tf,asset.ctxTf,asset.rangeThreshold)!=PHASE_RANGE)
          return false;
       const int lookback=20;
       int idxHigh=iHighest(symbol,tf,MODE_HIGH,lookback,1);

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/SpikeAndChannel.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/SpikeAndChannel.mqh
@@ -6,6 +6,8 @@
 
 class SpikeAndChannel
 {
+private:
+   MarketContextAnalyzer m_ctx;
 public:
    SpikeAndChannel(){}
    ~SpikeAndChannel(){}
@@ -13,8 +15,7 @@ public:
    // Identify a Spike and Channel pattern using a simplified rule set
    bool Identify(const string symbol,ENUM_TIMEFRAMES tf,const AssetConfig &asset)
    {
-      MarketContextAnalyzer ctx;
-      if(ctx.DetectPhaseMTF(symbol,tf,asset.ctxTf,asset.rangeThreshold)!=PHASE_TREND)
+      if(m_ctx.DetectPhaseMTF(symbol,tf,asset.ctxTf,asset.rangeThreshold)!=PHASE_TREND)
          return false;
       // skip if price is in mean reversion zone between EMA50 and EMA200
       if(CheckMeanReversion50to200(symbol,tf))

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/SpikeAndChannel.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/SpikeAndChannel.mqh
@@ -2,6 +2,7 @@
 #define INTEGRATEDPA_SPIKEANDCHANNEL_MQH
 #include "../Defs.mqh"
 #include "../Utils.mqh"
+#include "../MarketContext.mqh"
 
 class SpikeAndChannel
 {
@@ -10,8 +11,11 @@ public:
    ~SpikeAndChannel(){}
 
    // Identify a Spike and Channel pattern using a simplified rule set
-   bool Identify(const string symbol,ENUM_TIMEFRAMES tf)
+   bool Identify(const string symbol,ENUM_TIMEFRAMES tf,const AssetConfig &asset)
    {
+      MarketContextAnalyzer ctx;
+      if(ctx.DetectPhaseMTF(symbol,tf,asset.ctxTf,asset.rangeThreshold)!=PHASE_TREND)
+         return false;
       // skip if price is in mean reversion zone between EMA50 and EMA200
       if(CheckMeanReversion50to200(symbol,tf))
          return false;
@@ -54,15 +58,17 @@ public:
    }
 
    // Generate a basic trade signal when a spike is detected
-   Signal GenerateSignal(const string symbol,ENUM_TIMEFRAMES tf)
+   Signal GenerateSignal(const string symbol,ENUM_TIMEFRAMES tf,const AssetConfig &asset)
    {
       Print("GenerateSignal VALIDANDO SPIKE AND CHANNEL..........");
       Signal s; s.valid=false;
       double point=SymbolInfoDouble(symbol,SYMBOL_POINT);
-
-      if(!Identify(symbol,tf))
+      if(!Identify(symbol,tf,asset))
+      {
          Print("GenerateSignal FALHOU DESGRAÇADAMENTE..........");
          return s;
+      }
+
       
 // ##################################################################################################
       double close0=iClose(symbol,tf,1);

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/TrendRangeDay.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/TrendRangeDay.mqh
@@ -6,6 +6,8 @@
 
 class TrendRangeDay
 {
+private:
+   MarketContextAnalyzer m_ctx;
 public:
    TrendRangeDay(){}
    ~TrendRangeDay(){}
@@ -15,8 +17,7 @@ public:
    // moving in the direction of the trend
    bool Identify(const string symbol,ENUM_TIMEFRAMES tf,const AssetConfig &asset)
    {
-      MarketContextAnalyzer ctx;
-      if(ctx.DetectPhaseMTF(symbol,tf,asset.ctxTf,asset.rangeThreshold)!=PHASE_TREND)
+      if(m_ctx.DetectPhaseMTF(symbol,tf,asset.ctxTf,asset.rangeThreshold)!=PHASE_TREND)
          return false;
       // do not trade trend setups if price is mean reverting to the 50-200 zone
       if(CheckMeanReversion50to200(symbol,tf))

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/TrendRangeDay.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/TrendRangeDay.mqh
@@ -2,6 +2,7 @@
 #define INTEGRATEDPA_TRENDRANGEDAY_MQH
 #include "../Defs.mqh"
 #include "../Utils.mqh"
+#include "../MarketContext.mqh"
 
 class TrendRangeDay
 {
@@ -12,8 +13,11 @@ public:
    // Identify a Trending Trading Range Day pattern
    // Based on guide lines 3955-3970 describing consecutive ranges
    // moving in the direction of the trend
-   bool Identify(const string symbol,ENUM_TIMEFRAMES tf)
+   bool Identify(const string symbol,ENUM_TIMEFRAMES tf,const AssetConfig &asset)
    {
+      MarketContextAnalyzer ctx;
+      if(ctx.DetectPhaseMTF(symbol,tf,asset.ctxTf,asset.rangeThreshold)!=PHASE_TREND)
+         return false;
       // do not trade trend setups if price is mean reverting to the 50-200 zone
       if(CheckMeanReversion50to200(symbol,tf))
          return false;
@@ -45,11 +49,11 @@ public:
    }
 
    // Generate breakout signal from the last range
-   Signal GenerateSignal(const string symbol,ENUM_TIMEFRAMES tf)
+   Signal GenerateSignal(const string symbol,ENUM_TIMEFRAMES tf,const AssetConfig &asset)
    {
       Signal s; s.valid=false;
 
-      if(!Identify(symbol,tf))
+      if(!Identify(symbol,tf,asset))
          return s;
 
       double ema20=GetEMA(symbol,tf,20);

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/VWAPReversion.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/VWAPReversion.mqh
@@ -2,6 +2,7 @@
 #define INTEGRATEDPA_VWAPREVERSION_MQH
 #include "../Defs.mqh"
 #include "../Utils.mqh"
+#include "../MarketContext.mqh"
 
 class VWAPReversion
 {
@@ -10,8 +11,11 @@ public:
    ~VWAPReversion(){}
 
    // Identify when price is stretched away from VWAP and showing exhaustion
-   bool Identify(const string symbol,ENUM_TIMEFRAMES tf,bool &buySignal)
+   bool Identify(const string symbol,ENUM_TIMEFRAMES tf,bool &buySignal,const AssetConfig &asset)
    {
+      MarketContextAnalyzer ctx;
+      if(ctx.DetectPhaseMTF(symbol,tf,asset.ctxTf,asset.rangeThreshold)!=PHASE_REVERSAL)
+         return false;
       double vwap = GetVWAP(symbol,tf);
       double atr  = GetATR(symbol,tf,14);
       if(atr<=0.0) return false;
@@ -39,11 +43,11 @@ public:
    }
 
    // Generate trade signal targeting the VWAP
-   Signal GenerateSignal(const string symbol,ENUM_TIMEFRAMES tf)
+   Signal GenerateSignal(const string symbol,ENUM_TIMEFRAMES tf,const AssetConfig &asset)
    {
       Signal s; s.valid=false;
       bool buy=false;
-      if(!Identify(symbol,tf,buy))
+      if(!Identify(symbol,tf,buy,asset))
          return s;
 
       double vwap = GetVWAP(symbol,tf);

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/VWAPReversion.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/VWAPReversion.mqh
@@ -6,6 +6,8 @@
 
 class VWAPReversion
 {
+private:
+   MarketContextAnalyzer m_ctx;
 public:
    VWAPReversion(){}
    ~VWAPReversion(){}
@@ -13,8 +15,7 @@ public:
    // Identify when price is stretched away from VWAP and showing exhaustion
    bool Identify(const string symbol,ENUM_TIMEFRAMES tf,bool &buySignal,const AssetConfig &asset)
    {
-      MarketContextAnalyzer ctx;
-      if(ctx.DetectPhaseMTF(symbol,tf,asset.ctxTf,asset.rangeThreshold)!=PHASE_REVERSAL)
+      if(m_ctx.DetectPhaseMTF(symbol,tf,asset.ctxTf,asset.rangeThreshold)!=PHASE_REVERSAL)
          return false;
       double vwap = GetVWAP(symbol,tf);
       double atr  = GetATR(symbol,tf,14);

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/WedgeReversal.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/WedgeReversal.mqh
@@ -5,6 +5,8 @@
 
 class WedgeReversal
 {
+private:
+   MarketContextAnalyzer m_ctx;
 public:
    WedgeReversal(){}
    ~WedgeReversal(){}
@@ -12,8 +14,7 @@ public:
    // Identify rising/falling wedge as described in guide lines 4316-4379
    bool Identify(const string symbol,ENUM_TIMEFRAMES tf,bool &isRising,const AssetConfig &asset)
    {
-      MarketContextAnalyzer ctx;
-      if(ctx.DetectPhaseMTF(symbol,tf,asset.ctxTf,asset.rangeThreshold)!=PHASE_REVERSAL)
+      if(m_ctx.DetectPhaseMTF(symbol,tf,asset.ctxTf,asset.rangeThreshold)!=PHASE_REVERSAL)
          return false;
       isRising=false;
 

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/WedgeReversal.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/WedgeReversal.mqh
@@ -1,6 +1,7 @@
 #ifndef INTEGRATEDPA_WEDGEREVERSAL_MQH
 #define INTEGRATEDPA_WEDGEREVERSAL_MQH
 #include "../Defs.mqh"
+#include "../MarketContext.mqh"
 
 class WedgeReversal
 {
@@ -9,8 +10,11 @@ public:
    ~WedgeReversal(){}
 
    // Identify rising/falling wedge as described in guide lines 4316-4379
-   bool Identify(const string symbol,ENUM_TIMEFRAMES tf,bool &isRising)
+   bool Identify(const string symbol,ENUM_TIMEFRAMES tf,bool &isRising,const AssetConfig &asset)
    {
+      MarketContextAnalyzer ctx;
+      if(ctx.DetectPhaseMTF(symbol,tf,asset.ctxTf,asset.rangeThreshold)!=PHASE_REVERSAL)
+         return false;
       isRising=false;
 
       double h1=iHigh(symbol,tf,1);
@@ -40,11 +44,11 @@ public:
    }
 
    // Generate reversal signal on breakout of the wedge
-   Signal GenerateSignal(const string symbol,ENUM_TIMEFRAMES tf)
+   Signal GenerateSignal(const string symbol,ENUM_TIMEFRAMES tf,const AssetConfig &asset)
    {
       Signal s; s.valid=false;
       bool rising=false;
-      if(!Identify(symbol,tf,rising))
+      if(!Identify(symbol,tf,rising,asset))
          return s;
 
       double close0=iClose(symbol,tf,0);

--- a/prStory/Task_PersistentMarketContext_Summary.md
+++ b/prStory/Task_PersistentMarketContext_Summary.md
@@ -1,0 +1,47 @@
+# Task: Persistent Market Context per Strategy
+**Date:** 2025-06-20 18:47 UTC
+
+## Problem
+The EA previously created a new `MarketContextAnalyzer` each time a strategy was called. This repeated instantiation increased processing overhead and prevented context information from persisting across ticks.
+
+## Solution
+Strategies now hold a private `MarketContextAnalyzer` instance. `SignalEngine` stores each strategy as a member so the same object—and therefore the same context—is reused on every tick. `OnTick` simply calls `g_engine.Generate` without recreating strategies.
+
+### Code (excerpt)
+```mql5
+// SignalEngine.mqh
+Signal Generate(const string symbol,ENUM_TIMEFRAMES tf,const AssetConfig &asset)
+{
+    if(UseSpikeAndChannel)
+    {
+        if(m_spikeAndChannel.Identify(symbol,tf,asset))
+            return m_spikeAndChannel.GenerateSignal(symbol,tf,asset);
+    }
+    ...
+}
+
+private:
+    SpikeAndChannel      m_spikeAndChannel;
+    PullbackToMA         m_pullbackMA;
+    ...
+```
+```mql5
+// SpikeAndChannel.mqh
+class SpikeAndChannel
+{
+private:
+    MarketContextAnalyzer m_ctx;
+public:
+    bool Identify(const string symbol,ENUM_TIMEFRAMES tf,const AssetConfig &asset)
+    {
+        if(m_ctx.DetectPhaseMTF(symbol,tf,asset.ctxTf,asset.rangeThreshold)!=PHASE_TREND)
+            return false;
+        ...
+    }
+};
+```
+
+## Manual Testing Instructions
+- [ ] Compile the EA in MetaEditor and check for errors.
+- [ ] Run the EA on a demo account and verify that log messages show strategies being reused across ticks without recreation.
+


### PR DESCRIPTION
## Summary
- move market phase detection into each strategy
- simplify SignalEngine to call strategies directly
- adapt EA to use strategy-defined phases for risk

## Testing
- `bash scripts/compile.sh` *(fails: wine not available)*

------
https://chatgpt.com/codex/tasks/task_e_685587a676288320bd89d03a20908bba