### PR TITLE
Fix SpikeAndChannel and modularize strategies

### DIFF
--- a/IntegratedPA_EA/MQL5/Experts/IntegratedPA_EA.mq5
+++ b/IntegratedPA_EA/MQL5/Experts/IntegratedPA_EA.mq5
@@ -367,6 +367,8 @@ int OnInit()
    ResetDailyLimits();
 
    g_market = new MarketContext();
+   if(g_market && g_log)
+      g_market.SetLogger(g_log);
    g_engine = new SignalEngine();
    g_risk = new RiskManager(RiskPerTrade, MaxTotalRisk);
    g_exec = new TradeExecutor();

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/MarketContext.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/MarketContext.mqh
@@ -1,6 +1,7 @@
 #ifndef INTEGRATEDPA_MARKETCONTEXT_MQH
 #define INTEGRATEDPA_MARKETCONTEXT_MQH
 #include "Utils.mqh"
+#include "Logger.mqh"
 
 /// Informacoes retornadas pela analise de contexto
 struct PhaseInfo
@@ -17,10 +18,12 @@ struct PhaseInfo
 class MarketContextAnalyzer
 {
 public:
-   MarketContextAnalyzer() {}
+   MarketContextAnalyzer():m_logger(NULL) {}
    ~MarketContextAnalyzer() {}
+   void SetLogger(Logger *logger){m_logger=logger;}
 
 private:
+   Logger *m_logger;
    // suporte e resistencia em varios timeframes
    SRLevels sr_macro, sr_alto, sr_medio, sr_micro;
    // garante que ha historico suficiente
@@ -150,7 +153,10 @@ private:
                 DoubleToString(rsi, 1);
          if (above200)
             desc += ", acima da EMA200";
-         Print(desc);
+         if(m_logger!=NULL)
+            m_logger.Log(LOG_DEBUG,"[TrendPhase " + symbol + " " + EnumToString(tf) + "] " + desc);
+         else
+            Print("TrendPhase:"+symbol+" "+EnumToString(tf)+" - "+desc);
          return true;
       }
 
@@ -161,12 +167,18 @@ private:
                 DoubleToString(rsi, 1);
          if (below200)
             desc += ", abaixo da EMA200";
-         Print(desc);
+         if(m_logger!=NULL)
+            m_logger.Log(LOG_DEBUG,"[TrendPhase " + symbol + " " + EnumToString(tf) + "] " + desc);
+         else
+            Print("TrendPhase:"+symbol+" "+EnumToString(tf)+" - "+desc);
          return true;
       }
 
       desc = "Sem Tendência em: " +  EnumToString(tf);
-         Print(desc);
+         if(m_logger!=NULL)
+            m_logger.Log(LOG_DEBUG,"[TrendPhase " + symbol + " " + EnumToString(tf) + "] " + desc);
+         else
+            Print("TrendPhase:"+symbol+" "+EnumToString(tf)+" - "+desc);
 
       return false;
    }
@@ -252,7 +264,13 @@ public:
    PhaseInfo DetectPhaseMTF(const string symbol, const ENUM_TIMEFRAMES &tfs[], int count,
                             double rangeThr = 10.0)
    {
-      Print("TIMEFRAMES EM DETECTPHASE MTF: " + EnumToString(tfs[0])+", "+ EnumToString(tfs[1]));
+      string tfList="";
+      for(int i=0;i<count && i<4;i++)
+         tfList+=((i>0)?", ":"")+EnumToString(tfs[i]);
+      if(m_logger!=NULL)
+         m_logger.Log(LOG_DEBUG,"[DetectPhaseMTF " + symbol + "] tfs=" + tfList);
+      else
+         Print("DetectPhaseMTF " + symbol + " tfs=" + tfList);
 
       PhaseInfo localInfos[4];
       string details = "";

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/SignalEngine.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/SignalEngine.mqh
@@ -115,16 +115,34 @@ public:
 
    Signal Generate(const string symbol,MARKET_PHASE phase,ENUM_TIMEFRAMES tf)
    {
-      IStrategy **list=NULL;
-      int count=0;
-      if(phase==PHASE_TREND){ list=m_trend; count=ArraySize(m_trend); }
-      else if(phase==PHASE_RANGE){ list=m_range; count=ArraySize(m_range); }
-      else if(phase==PHASE_REVERSAL){ list=m_reversal; count=ArraySize(m_reversal); }
       Signal s; s.valid=false;
-      for(int i=0;i<count;i++)
+
+      if(phase==PHASE_TREND)
       {
-         if(list[i].Identify(symbol,tf))
-            return list[i].GenerateSignal(symbol,tf);
+         int count=ArraySize(m_trend);
+         for(int i=0;i<count;i++)
+         {
+            if(m_trend[i].Identify(symbol,tf))
+               return m_trend[i].GenerateSignal(symbol,tf);
+         }
+      }
+      else if(phase==PHASE_RANGE)
+      {
+         int count=ArraySize(m_range);
+         for(int i=0;i<count;i++)
+         {
+            if(m_range[i].Identify(symbol,tf))
+               return m_range[i].GenerateSignal(symbol,tf);
+         }
+      }
+      else if(phase==PHASE_REVERSAL)
+      {
+         int count=ArraySize(m_reversal);
+         for(int i=0;i<count;i++)
+         {
+            if(m_reversal[i].Identify(symbol,tf))
+               return m_reversal[i].GenerateSignal(symbol,tf);
+         }
       }
       return s;
    }

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/BollingerStochastic.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/BollingerStochastic.mqh
@@ -2,15 +2,17 @@
 #define INTEGRATEDPA_BOLLINGERSTOCHASTIC_MQH
 #include "../Defs.mqh"
 #include "../Utils.mqh"
+#include "StrategyBase.mqh"
 
 // Strategy combining Bollinger Bands context with Stochastic timing
-class BollingerStochastic
+class BollingerStochastic : public IStrategy
 {
 private:
    bool m_buy;
 public:
    BollingerStochastic():m_buy(false){}
    ~BollingerStochastic(){}
+   string Name() const override { return "BollStoch"; }
 
    // Identify setup according to guide lines 3600-3625
    bool Identify(const string symbol,ENUM_TIMEFRAMES tf)

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/FibonacciRetrace.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/FibonacciRetrace.mqh
@@ -2,12 +2,13 @@
 #define INTEGRATEDPA_FIBONACCIRETRACE_MQH
 #include "../Defs.mqh"
 #include "../Utils.mqh"
+#include "StrategyBase.mqh"
 
 // Estrat\u00e9gia de revers\u00e3o na zona de ouro (61,8% de Fibonacci)
 // Inspirada nas orienta\u00e7\u00f5es do guia de trading em torno das linhas
 // 640-665 que destacam compras e vendas quando o pre\u00e7o reage ao n\u00edvel
 // de 61,8% ap\u00f3s um movimento tendencial.
-class FibonacciRetrace
+class FibonacciRetrace : public IStrategy
 {
 private:
    double m_high;
@@ -16,6 +17,7 @@ private:
 public:
    FibonacciRetrace():m_high(0),m_low(0),m_buySignal(false){}
    ~FibonacciRetrace(){}
+   string Name() const override { return "FiboRetrace"; }
 
    // Identifica a presen\u00e7a de retra\u00e7\u00e3o at\u00e9 61,8% e candle de revers\u00e3o
    bool Identify(const string symbol,ENUM_TIMEFRAMES tf)

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/MeanReversion50to200.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/MeanReversion50to200.mqh
@@ -17,6 +17,11 @@ public:
    MeanReversion50to200(){}
    ~MeanReversion50to200(){}
    string Name() const override { return "MR50to200"; }
+   bool Identify(const string symbol,ENUM_TIMEFRAMES tf) override
+   {
+      bool dummy=false;
+      return Identify(symbol,tf,dummy);
+   }
 
    // Identify mean reversion opportunity
    bool Identify(const string symbol,ENUM_TIMEFRAMES tf,bool &buySignal)

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/MeanReversion50to200.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/MeanReversion50to200.mqh
@@ -2,6 +2,7 @@
 #define INTEGRATEDPA_MEANREV50TO200_MQH
 #include "../Defs.mqh"
 #include "../Utils.mqh"
+#include "StrategyBase.mqh"
 
 //+------------------------------------------------------------------+
 //| Mean Reversion from EMA50 to EMA200                              |
@@ -10,11 +11,12 @@
 //| around 1316-1455). This strategy enters near the midpoint        |
 //| between EMA50 and EMA200 once price shows exhaustion.            |
 //+------------------------------------------------------------------+
-class MeanReversion50to200
+class MeanReversion50to200 : public IStrategy
 {
 public:
    MeanReversion50to200(){}
    ~MeanReversion50to200(){}
+   string Name() const override { return "MR50to200"; }
 
    // Identify mean reversion opportunity
    bool Identify(const string symbol,ENUM_TIMEFRAMES tf,bool &buySignal)

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/PullbackToMA.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/PullbackToMA.mqh
@@ -2,12 +2,14 @@
 #define INTEGRATEDPA_PULLBACKTOMA_MQH
 #include "../Defs.mqh"
 #include "../Utils.mqh"
+#include "StrategyBase.mqh"
 
-class PullbackToMA
+class PullbackToMA : public IStrategy
 {
 public:
     PullbackToMA(){}
     ~PullbackToMA(){}
+    string Name() const override { return "PullbackMA"; }
 
     bool Identify(const string symbol, ENUM_TIMEFRAMES tf)
     {

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/RangeBreakout.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/RangeBreakout.mqh
@@ -2,8 +2,9 @@
 #define INTEGRATEDPA_RANGEBREAKOUT_MQH
 #include "../Defs.mqh"
 #include "../Utils.mqh"
+#include "StrategyBase.mqh"
 
-class RangeBreakout
+class RangeBreakout : public IStrategy
 {
 private:
    double m_high;
@@ -12,6 +13,7 @@ private:
 public:
    RangeBreakout():m_high(0),m_low(0),m_buySignal(false){}
    ~RangeBreakout(){}
+   string Name() const override { return "RangeBreak"; }
 
    // Identify breakout beyond range boundaries with volume/VWAP confirmation
    bool Identify(const string symbol,ENUM_TIMEFRAMES tf)

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/RangeFade.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/RangeFade.mqh
@@ -1,8 +1,9 @@
 #ifndef INTEGRATEDPA_RANGEFADE_MQH
 #define INTEGRATEDPA_RANGEFADE_MQH
 #include "../Defs.mqh"
+#include "StrategyBase.mqh"
 
-class RangeFade
+class RangeFade : public IStrategy
 {
 private:
    double m_high;
@@ -11,6 +12,7 @@ private:
 public:
    RangeFade():m_high(0),m_low(0),m_buySignal(false){}
    ~RangeFade(){}
+   string Name() const override { return "RangeFade"; }
 
    // Identify rejection at range extremes
    bool Identify(const string symbol,ENUM_TIMEFRAMES tf)

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/SpikeAndChannel.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/SpikeAndChannel.mqh
@@ -2,12 +2,14 @@
 #define INTEGRATEDPA_SPIKEANDCHANNEL_MQH
 #include "../Defs.mqh"
 #include "../Utils.mqh"
+#include "StrategyBase.mqh"
 
-class SpikeAndChannel
+class SpikeAndChannel : public IStrategy
 {
 public:
    SpikeAndChannel(){}
    ~SpikeAndChannel(){}
+   string Name() const override { return "SpikeChannel"; }
 
    // Identify a Spike and Channel pattern using a simplified rule set
    bool Identify(const string symbol,ENUM_TIMEFRAMES tf)
@@ -61,8 +63,10 @@ public:
       double point=SymbolInfoDouble(symbol,SYMBOL_POINT);
 
       if(!Identify(symbol,tf))
+      {
          Print("GenerateSignal FALHOU DESGRAÇADAMENTE..........");
          return s;
+      }
       
 // ##################################################################################################
       double close0=iClose(symbol,tf,1);

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/StrategyBase.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/StrategyBase.mqh
@@ -1,0 +1,15 @@
+#ifndef INTEGRATEDPA_STRATEGYBASE_MQH
+#define INTEGRATEDPA_STRATEGYBASE_MQH
+#include "../Defs.mqh"
+#include "../Utils.mqh"
+
+class IStrategy
+{
+public:
+    virtual ~IStrategy() {}
+    virtual string Name() const = 0;
+    virtual bool Identify(const string symbol, ENUM_TIMEFRAMES tf) = 0;
+    virtual Signal GenerateSignal(const string symbol, ENUM_TIMEFRAMES tf) = 0;
+};
+
+#endif // INTEGRATEDPA_STRATEGYBASE_MQH

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/TrendRangeDay.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/TrendRangeDay.mqh
@@ -2,12 +2,14 @@
 #define INTEGRATEDPA_TRENDRANGEDAY_MQH
 #include "../Defs.mqh"
 #include "../Utils.mqh"
+#include "StrategyBase.mqh"
 
-class TrendRangeDay
+class TrendRangeDay : public IStrategy
 {
 public:
    TrendRangeDay(){}
    ~TrendRangeDay(){}
+   string Name() const override { return "TrendRangeDay"; }
 
    // Identify a Trending Trading Range Day pattern
    // Based on guide lines 3955-3970 describing consecutive ranges

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/VWAPReversion.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/VWAPReversion.mqh
@@ -2,12 +2,14 @@
 #define INTEGRATEDPA_VWAPREVERSION_MQH
 #include "../Defs.mqh"
 #include "../Utils.mqh"
+#include "StrategyBase.mqh"
 
-class VWAPReversion
+class VWAPReversion : public IStrategy
 {
 public:
    VWAPReversion(){}
    ~VWAPReversion(){}
+   string Name() const override { return "VWAPRev"; }
 
    // Identify when price is stretched away from VWAP and showing exhaustion
    bool Identify(const string symbol,ENUM_TIMEFRAMES tf,bool &buySignal)

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/VWAPReversion.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/VWAPReversion.mqh
@@ -10,6 +10,11 @@ public:
    VWAPReversion(){}
    ~VWAPReversion(){}
    string Name() const override { return "VWAPRev"; }
+   bool Identify(const string symbol,ENUM_TIMEFRAMES tf) override
+   {
+      bool dummy=false;
+      return Identify(symbol,tf,dummy);
+   }
 
    // Identify when price is stretched away from VWAP and showing exhaustion
    bool Identify(const string symbol,ENUM_TIMEFRAMES tf,bool &buySignal)

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/WedgeReversal.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/WedgeReversal.mqh
@@ -9,6 +9,11 @@ public:
    WedgeReversal(){}
    ~WedgeReversal(){}
    string Name() const override { return "WedgeRev"; }
+   bool Identify(const string symbol,ENUM_TIMEFRAMES tf) override
+   {
+      bool dummy=false;
+      return Identify(symbol,tf,dummy);
+   }
 
    // Identify rising/falling wedge as described in guide lines 4316-4379
    bool Identify(const string symbol,ENUM_TIMEFRAMES tf,bool &isRising)

--- a/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/WedgeReversal.mqh
+++ b/IntegratedPA_EA/MQL5/Include/IntegratedPA/strategies/WedgeReversal.mqh
@@ -1,12 +1,14 @@
 #ifndef INTEGRATEDPA_WEDGEREVERSAL_MQH
 #define INTEGRATEDPA_WEDGEREVERSAL_MQH
 #include "../Defs.mqh"
+#include "StrategyBase.mqh"
 
-class WedgeReversal
+class WedgeReversal : public IStrategy
 {
 public:
    WedgeReversal(){}
    ~WedgeReversal(){}
+   string Name() const override { return "WedgeRev"; }
 
    // Identify rising/falling wedge as described in guide lines 4316-4379
    bool Identify(const string symbol,ENUM_TIMEFRAMES tf,bool &isRising)


### PR DESCRIPTION
## Summary
- fix missing braces in SpikeAndChannel strategy
- introduce new `IStrategy` interface for strategies
- update all strategy classes to implement the interface
- rework `SignalEngine` to hold strategy lists for better modularity

## Testing
- `bash scripts/compile.sh` *(fails: wine not available)*

------
https://chatgpt.com/codex/tasks/task_e_6855d77c04508320b0ff8ae250686290